### PR TITLE
Allowing environment independent build

### DIFF
--- a/sources/core/env/main.tf
+++ b/sources/core/env/main.tf
@@ -86,8 +86,6 @@ module "cbsbackup" {
   kube_client_cert = module.aks.kube_client_cert
   kube_client_key  = module.aks.kube_client_key
   kube_cluster_ca  = module.aks.kube_cluster_ca
-  domain           = data.azurerm_key_vault_secret.cbs_vault["domain"].value
-
   harbor_namespace = "harbor"
   argocd_namespace = "argocd"
   storage_name     = azurerm_storage_account.harbor_storage.name

--- a/sources/core/env/main.tf
+++ b/sources/core/env/main.tf
@@ -86,6 +86,7 @@ module "cbsbackup" {
   kube_client_cert = module.aks.kube_client_cert
   kube_client_key  = module.aks.kube_client_key
   kube_cluster_ca  = module.aks.kube_cluster_ca
+  domain           = "${data.azurerm_key_vault_secret.cbs_vault["domain"].value}"
 
   harbor_namespace = "harbor"
   argocd_namespace = "argocd"

--- a/sources/core/env/main.tf
+++ b/sources/core/env/main.tf
@@ -1,7 +1,7 @@
 module "basic" {
   source = "../modules/basic"
 
-  name             = var.project_name
+  name             = var.enviroment
   size             = var.no_vms
   use_public_ip    = var.use_public_ips
   rsa_pub_path     = var.key_path
@@ -13,7 +13,7 @@ module "basic" {
 module "aks" {
   source = "../modules/aks"
 
-  name                         = "cbs-${var.project_name}-aks"
+  name                         = "cbs-${var.enviroment}-aks"
   rg_name                      = module.basic.rg_name
   subnet_id                    = module.basic.subnet_id[0]
   default_node_pool_max_number = var.max_aks_nodes_number
@@ -56,7 +56,7 @@ module "k8s" {
   tekton_operator_container = data.azurerm_key_vault_secret.cbs_vault["tekton-operator-container"].value
   kubernetes_subnet_cidr    = module.basic.subnet_cidrs[0]
   location                  = data.azurerm_key_vault_secret.cbs_vault["location"].value
-  name                      = "${var.project_name}-appgw"
+  name                      = "${var.enviroment}-appgw"
   rg_name                   = module.basic.rg_name
   subnet_id                 = module.basic.subnet_id[1]
   appgw_subnet_cidr         = module.basic.subnet_cidrs[1]

--- a/sources/core/env/main.tf
+++ b/sources/core/env/main.tf
@@ -86,7 +86,7 @@ module "cbsbackup" {
   kube_client_cert = module.aks.kube_client_cert
   kube_client_key  = module.aks.kube_client_key
   kube_cluster_ca  = module.aks.kube_cluster_ca
-  domain           = "${data.azurerm_key_vault_secret.cbs_vault["domain"].value}"
+  domain           = data.azurerm_key_vault_secret.cbs_vault["domain"].value
 
   harbor_namespace = "harbor"
   argocd_namespace = "argocd"

--- a/sources/core/env/main.tf
+++ b/sources/core/env/main.tf
@@ -13,7 +13,7 @@ module "basic" {
 module "aks" {
   source = "../modules/aks"
 
-  name                         = "${var.project_name}-aks"
+  name                         = "cbs-${var.project_name}-aks"
   rg_name                      = module.basic.rg_name
   subnet_id                    = module.basic.subnet_id[0]
   default_node_pool_max_number = var.max_aks_nodes_number

--- a/sources/core/env/main.tf
+++ b/sources/core/env/main.tf
@@ -13,7 +13,7 @@ module "basic" {
 module "aks" {
   source = "../modules/aks"
 
-  name                         = var.project_name
+  name                         = "${var.project_name}-aks"
   rg_name                      = module.basic.rg_name
   subnet_id                    = module.basic.subnet_id[0]
   default_node_pool_max_number = var.max_aks_nodes_number

--- a/sources/core/env/provider.tf
+++ b/sources/core/env/provider.tf
@@ -1,5 +1,4 @@
 provider "azurerm" {
-  version = "2.27.0"
   features {}
 }
 

--- a/sources/core/env/storage.tf
+++ b/sources/core/env/storage.tf
@@ -7,13 +7,13 @@ resource "azurerm_storage_account" "harbor_storage" {
 }
 
 resource "azurerm_storage_container" "harbor_container" {
-  name                  = "vhds"
+  name                  = "cbs-${var.enviroment}-vhds"
   storage_account_name  = azurerm_storage_account.harbor_storage.name
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "cbs_backup" {
-  name                  = "cbsbackup"
+  name                  = "cbs-${var.enviroment}-backup"
   storage_account_name  = azurerm_storage_account.harbor_storage.name
   container_access_type = "private"
 }

--- a/sources/core/env/storage.tf
+++ b/sources/core/env/storage.tf
@@ -1,6 +1,6 @@
 resource "azurerm_storage_account" "harbor_storage" {
   name                     = data.azurerm_key_vault_secret.cbs_vault["harbor-storage-account-name"].value
-  resource_group_name      = module.basic.rg_name
+  resource_group_name      = data.azurerm_key_vault_secret.cbs_vault["harbor-storage-rg-name"].value
   location                 = data.azurerm_key_vault_secret.cbs_vault["location"].value
   account_tier             = "Standard"
   account_replication_type = "LRS"

--- a/sources/core/env/terraform.tfvars
+++ b/sources/core/env/terraform.tfvars
@@ -1,1 +1,1 @@
-project_name = "your_project_name"
+project_name = "your_project_name"   # will be used for naming and addressing your Azure RGs

--- a/sources/core/env/terraform.tfvars
+++ b/sources/core/env/terraform.tfvars
@@ -1,1 +1,0 @@
-project_name = "your_project_name"   # will be used for naming and addressing your Azure RGs

--- a/sources/core/env/variables.tf
+++ b/sources/core/env/variables.tf
@@ -1,4 +1,8 @@
 ### BASIC VARS
+variable "enviroment" {
+  default = "tst"
+}
+
 variable project_name {
   type = string
 }

--- a/sources/core/env/variables.tf
+++ b/sources/core/env/variables.tf
@@ -3,10 +3,6 @@ variable "enviroment" {
   default = "tst"
 }
 
-variable project_name {
-  type = string
-}
-
 variable "key_path" {
   default = "shared/.pub"
 }

--- a/sources/core/env/vault.tf
+++ b/sources/core/env/vault.tf
@@ -1,6 +1,6 @@
 data "azurerm_key_vault" "cbs" {
-  name                = "cbs-${var.enviroment}-kv"     //var.keyvault_name
-  resource_group_name = "cbs-tools-rg" //var.keyvault_rg
+  name                = "cbs-${var.enviroment}-kv"
+  resource_group_name = "cbs-tools-rg"
 }
 
 data "azurerm_key_vault_secret" "cbs_vault" {

--- a/sources/core/env/vault.tf
+++ b/sources/core/env/vault.tf
@@ -21,7 +21,8 @@ data "azurerm_key_vault_secret" "cbs_vault" {
     "tekton-operator-container",
     "harbor-prefix",
     "harbor-tls-secret-name",
-    "harbor-storage-account-name"
+    "harbor-storage-account-name",
+    "harbor-storage-rg-name"
   ])
   name         = each.value
   key_vault_id = data.azurerm_key_vault.cbs.id

--- a/sources/core/env/vault.tf
+++ b/sources/core/env/vault.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault" "cbs" {
-  name                = "cbs-prod"     //var.keyvault_name
+  name                = "cbs-${var.enviroment}-kv"     //var.keyvault_name
   resource_group_name = "cbs-tools-rg" //var.keyvault_rg
 }
 

--- a/sources/core/modules/aks/main.tf
+++ b/sources/core/modules/aks/main.tf
@@ -36,6 +36,11 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
   }
 
+  tags = {
+    env = var.name
+    CreatedWhen = timestamp()
+  }
+
   addon_profile {
     aci_connector_linux {
       enabled = false
@@ -53,4 +58,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
       enabled = false
     }
   }
+}
+
+output "pvlink_ready" {
+  value = "true"
 }

--- a/sources/core/modules/aks/main.tf
+++ b/sources/core/modules/aks/main.tf
@@ -37,7 +37,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   tags = {
-    env = var.name
+    Env = var.name
     CreatedWhen = timestamp()
   }
 

--- a/sources/core/modules/aks/variables.tf
+++ b/sources/core/modules/aks/variables.tf
@@ -62,7 +62,7 @@ variable "private_cluster" {
 
 variable "kubernetes_version" {
   type        = string
-  default     = "1.18.14"
+  default     = "1.18.17"
   description = "your kubernetes version"
 }
 

--- a/sources/core/modules/basic/main.tf
+++ b/sources/core/modules/basic/main.tf
@@ -1,4 +1,9 @@
 resource "azurerm_resource_group" "rg" {
   name     = "${var.name}-rg"
   location = var.location
+   
+  tags = {
+    env = var.name
+    CreatedWhen = timestamp()
+  }
 }

--- a/sources/core/modules/basic/main.tf
+++ b/sources/core/modules/basic/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.name}-rg"
+  name     = "cbs-${var.name}-rg"
   location = var.location
    
   tags = {

--- a/sources/core/modules/basic/main.tf
+++ b/sources/core/modules/basic/main.tf
@@ -3,7 +3,7 @@ resource "azurerm_resource_group" "rg" {
   location = var.location
    
   tags = {
-    env = var.name
+    Env = var.name
     CreatedWhen = timestamp()
   }
 }

--- a/sources/core/modules/basic/modules/vms/main.tf
+++ b/sources/core/modules/basic/modules/vms/main.tf
@@ -1,6 +1,6 @@
 resource "azurerm_public_ip" "pubip" {
   count                   = var.use_public_ip != true ? 0 : var.instances
-  name                    = "${var.name}-${var.service}-${count.index}-pubip"
+  name                    = "cbs-${var.name}-${var.service}-${count.index}-pubip"
   location                = var.location
   resource_group_name     = var.rg_name
   allocation_method       = "Static"
@@ -10,7 +10,7 @@ resource "azurerm_public_ip" "pubip" {
 
 resource "azurerm_network_interface" "nic" {
   count                         = var.instances
-  name                          = "${var.name}-${var.service}-${count.index}-nic"
+  name                          = "cbs-${var.name}-${var.service}-${count.index}-nic"
   location                      = var.location
   resource_group_name           = var.rg_name
   enable_accelerated_networking = "false"
@@ -50,7 +50,7 @@ resource "azurerm_network_interface_security_group_association" "nic-nsg-assoc" 
 
 resource "azurerm_linux_virtual_machine" "vm" {
   count                 = var.instances
-  name                  = "${var.name}-${var.service}-${count.index}"
+  name                  = "cbs-${var.name}-${var.service}-${count.index}"
   location              = var.location
   resource_group_name   = var.rg_name
   size                  = var.vm_size
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   }
 
   os_disk {
-    name                 = "${var.name}-${var.service}-${count.index}-disk"
+    name                 = "cbs-${var.name}-${var.service}-${count.index}-disk"
     caching              = "ReadWrite"
     disk_size_gb         = "32"
     storage_account_type = "Premium_LRS"

--- a/sources/core/modules/basic/modules/vms/main.tf
+++ b/sources/core/modules/basic/modules/vms/main.tf
@@ -50,7 +50,7 @@ resource "azurerm_network_interface_security_group_association" "nic-nsg-assoc" 
 
 resource "azurerm_linux_virtual_machine" "vm" {
   count                 = var.instances
-  name                  = "cbs-${var.name}-${var.service}-${count.index}"
+  name                  = "cbs-${var.name}-${var.service}-${count.index}-vm"
   location              = var.location
   resource_group_name   = var.rg_name
   size                  = var.vm_size

--- a/sources/core/modules/basic/networking.tf
+++ b/sources/core/modules/basic/networking.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "vnet" {
-  name                = "${var.name}-vnet"
+  name                = "cbs-${var.name}-vnet"
   address_space       = [var.address_space]
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network" "vnet" {
 resource "azurerm_subnet" "subnet" {
   count                = pow(2, var.bits_for_subnets)
 
-  name                 = "${var.name}-snet-${count.index}"
+  name                 = "cbs-${var.name}-snet-${count.index}"
   address_prefixes     = [cidrsubnet(var.address_space, var.bits_for_subnets, count.index)]
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name

--- a/sources/core/modules/basic/networking.tf
+++ b/sources/core/modules/basic/networking.tf
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network" "vnet" {
 resource "azurerm_subnet" "subnet" {
   count                = pow(2, var.bits_for_subnets)
 
-  name                 = "cbs-${var.name}-snet-${count.index}"
+  name                 = "cbs-${var.name}-snet-${count.index}-snet"
   address_prefixes     = [cidrsubnet(var.address_space, var.bits_for_subnets, count.index)]
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name

--- a/sources/core/modules/basic/networking.tf
+++ b/sources/core/modules/basic/networking.tf
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network" "vnet" {
 resource "azurerm_subnet" "subnet" {
   count                = pow(2, var.bits_for_subnets)
 
-  name                 = "cbs-${var.name}-snet-${count.index}-snet"
+  name                 = "cbs-${var.name}-${count.index}-snet"
   address_prefixes     = [cidrsubnet(var.address_space, var.bits_for_subnets, count.index)]
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name

--- a/sources/core/modules/cbsbackup/variables.tf
+++ b/sources/core/modules/cbsbackup/variables.tf
@@ -32,3 +32,7 @@ variable "storage_name" {
 variable "container_name" {
   type    = string
 }
+
+variable "domain" {
+  type   = string
+}

--- a/sources/core/modules/cbsbackup/variables.tf
+++ b/sources/core/modules/cbsbackup/variables.tf
@@ -32,7 +32,3 @@ variable "storage_name" {
 variable "container_name" {
   type    = string
 }
-
-variable "domain" {
-  type   = string
-}

--- a/sources/core/modules/harbor/main.tf
+++ b/sources/core/modules/harbor/main.tf
@@ -2,7 +2,7 @@ resource "helm_release" "harbor" {
   name       = "harbor"
   repository = "https://helm.goharbor.io"
   chart      = "harbor"
-  version    = "1.3.6"
+  version    = var.harbor_version
 
   namespace        = var.namespace
   create_namespace = true

--- a/sources/core/modules/harbor/provider.tf
+++ b/sources/core/modules/harbor/provider.tf
@@ -1,5 +1,4 @@
 provider "azurerm" {
-  version = "2.27.0"
   features {}
 }
 

--- a/sources/core/modules/harbor/variables.tf
+++ b/sources/core/modules/harbor/variables.tf
@@ -50,3 +50,8 @@ variable "notary_url" {
   type    = string
   default = "notary.harbor.domain"
 }
+
+variable "harbor_version" {
+  type    = string
+  default = "1.3.6"
+}

--- a/sources/core/modules/harbor/variables.tf
+++ b/sources/core/modules/harbor/variables.tf
@@ -21,7 +21,7 @@ variable "storage_container_name" {
   description = "Container for harbor blobs"
 }
 
-variable "project_name" {
+variable "enviroment" {
   type    = string
   default = "cbs-harbor"
 }

--- a/sources/core/modules/harbor/variables.tf
+++ b/sources/core/modules/harbor/variables.tf
@@ -53,5 +53,5 @@ variable "notary_url" {
 
 variable "harbor_version" {
   type    = string
-  default = "1.3.6"
+  default = "1.6.2"
 }

--- a/sources/core/modules/k8s/api-gateway.tf
+++ b/sources/core/modules/k8s/api-gateway.tf
@@ -12,7 +12,7 @@ locals {
 resource "azurerm_public_ip" "app_gw_pub_ip_priv" {
   allocation_method   = "Static"
   location            = var.location
-  name                = "${var.name}-pub_ip_priv"
+  name                = "cbs-${var.name}-pub_ip_priv"
   resource_group_name = var.rg_name
   sku                 = "Standard"
 }

--- a/sources/core/modules/k8s/main.tf
+++ b/sources/core/modules/k8s/main.tf
@@ -1,3 +1,8 @@
+resource "null_resource" "test_if_peering_done" {
+  provisioner "local-exec" {
+    command = "echo Peering was done: \"${var.peering_done}\""
+  }
+}
 resource "null_resource" "kube_config_create" {
   provisioner "local-exec" {
     command = "echo \"${var.kubeconfig}\" > tf_kubeconfig"

--- a/sources/core/modules/k8s/prometheus.tf
+++ b/sources/core/modules/k8s/prometheus.tf
@@ -24,7 +24,7 @@ resource "helm_release" "prometheus" {
 
   set {
     name  = "prometheus.ingress.hosts[0]"
-    value = "prometheus.cbs.hasops.com"
+    value = "prometheus.${var.domain}"
   }
 
   set {

--- a/sources/init_vnet/main.tf
+++ b/sources/init_vnet/main.tf
@@ -1,24 +1,24 @@
 resource "azurerm_resource_group" "rg" {
-  name     = "${var.name}-rg"
+  name     = "cbs-${var.name}-rg"
   location = var.location
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  name                = "${var.name}-vnet"
+  name                = "cbs-${var.name}-vnet"
   address_space       = var.address_space
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
 }
 
 resource "azurerm_subnet" "subnet" {
-  name                 = "${var.name}-snet"
+  name                 = "cbs-${var.name}-snet"
   address_prefixes     = var.address_prefixes
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
 }
 
 resource "azurerm_public_ip" "pubip" {
-  name                    = "${var.name}-pubip"
+  name                    = "cbs-${var.name}-pubip"
   location                = var.location
   resource_group_name     = azurerm_resource_group.rg.name
   allocation_method       = "Static"
@@ -27,7 +27,7 @@ resource "azurerm_public_ip" "pubip" {
 }
 
 resource "azurerm_network_interface" "nic" {
-  name                          = "${var.name}-nic"
+  name                          = "cbs-${var.name}-nic"
   location                      = var.location
   resource_group_name           = azurerm_resource_group.rg.name
   enable_accelerated_networking = "false"
@@ -87,7 +87,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   }
 
   os_disk {
-    name                 = "${var.name}-disk"
+    name                 = "cbs-${var.name}-disk"
     caching              = "ReadWrite"
     disk_size_gb         = "32"
     storage_account_type = "Standard_LRS"

--- a/sources/init_vnet/main.tf
+++ b/sources/init_vnet/main.tf
@@ -64,7 +64,7 @@ resource "azurerm_network_interface_security_group_association" "nic-nsg-assoc" 
 }
 
 resource "azurerm_linux_virtual_machine" "vm" {
-  name                  = "${var.name}"
+  name                  = cbs-"${var.name}-vm"
   location              = var.location
   resource_group_name   = azurerm_resource_group.rg.name
   size                  = "Standard_D1_v2"


### PR DESCRIPTION
This PR is focused on updating the current code ( main branch ) in a sucha a way
that it would make it possible to build independent CBS environments, like: TST, DEV, UAT, etc...
Please note, that the current code state allows only for PROD building .

Also an emphasis was put on tagging and variable naming as it's important both for environment readability and its logical separation.
Some variables initialization scraps were moved to Azure KV so it could have be a central point of CBS initialization and configuration. 

Before going for this PR, the current branch code was successfully tested by subsequent builds of non-PROD environment.
Due to the subject code changes, these tests were completely secure and transparent to the existing PROD environment.
 