### PR TITLE
Code Fix: supplying the missing nginx TLS cert

### DIFF
--- a/sources/core/modules/k8s/nginx-ingress.tf
+++ b/sources/core/modules/k8s/nginx-ingress.tf
@@ -31,3 +31,16 @@ resource "kubernetes_service" "nginx_svc" {
     }
   }
 }
+
+resource "kubernetes_secret" "nginx_def_secret" {
+  metadata {
+    name      = var.nginx_secret
+    namespace = kubernetes_namespace.nginx_ns.metadata[0].name
+  }
+  type = "kubernetes.io/tls"
+  data = {
+    "tls.crt" = tls_self_signed_cert.cert.cert_pem
+    "tls.key" = tls_private_key.key.private_key_pem
+  }
+  lifecycle { ignore_changes = [data] }
+}


### PR DESCRIPTION
This PR provides TF code update, that is creating a kubernetes secret object in the nginx-ingress namespace.
This secret is used to keep the NGINX TLS certificate.
Without this certificate, the NGINS pod was refusing to start.

This code update was tested by building the CBS environment from the scratch.