### PR TITLE
Harbor and kubernetes versions are now centrally controlled in KV

### DIFF
--- a/sources/core/env/main.tf
+++ b/sources/core/env/main.tf
@@ -22,6 +22,7 @@ module "aks" {
   client_secret                = data.azurerm_key_vault_secret.cbs_vault["client-secret"].value
   tenant_id                    = data.azurerm_key_vault_secret.cbs_vault["tenant-id"].value
   aad_admin_groups             = [data.azurerm_key_vault_secret.cbs_vault["aad-admin-groups"].value]
+  kubernetes_version           = data.azurerm_key_vault_secret.cbs_vault["kubernetes-version"].value
 }
 
 module "peering" {
@@ -73,6 +74,7 @@ module "harbor" {
 
   harbor_url                 = "${var.harbor_prefix}.${data.azurerm_key_vault_secret.cbs_vault["domain"].value}"
   notary_url                 = "${var.notary_prefix}.${data.azurerm_key_vault_secret.cbs_vault["domain"].value}"
+  harbor_version             = data.azurerm_key_vault_secret.cbs_vault["harbor-version"].value
   storage_account_name       = azurerm_storage_account.harbor_storage.name
   storage_primary_access_key = azurerm_storage_account.harbor_storage.primary_access_key
   storage_container_name     = azurerm_storage_container.harbor_container.name

--- a/sources/core/env/vault.tf
+++ b/sources/core/env/vault.tf
@@ -22,7 +22,9 @@ data "azurerm_key_vault_secret" "cbs_vault" {
     "harbor-prefix",
     "harbor-tls-secret-name",
     "harbor-storage-account-name",
-    "harbor-storage-rg-name"
+    "harbor-storage-rg-name",
+    "harbor-version",
+    "kubernetes-version"
   ])
   name         = each.value
   key_vault_id = data.azurerm_key_vault.cbs.id

--- a/sources/core/modules/aks/main.tf
+++ b/sources/core/modules/aks/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dns_prefix              = var.dns_prefix
   private_cluster_enabled = var.private_cluster
   kubernetes_version      = var.kubernetes_version
+  
   default_node_pool {
     name                = substr(join("", [replace(var.name, "-", ""), "dnp"]), 0, 12)
     vm_size             = var.default_node_pool_vm_size

--- a/sources/core/modules/aks/variables.tf
+++ b/sources/core/modules/aks/variables.tf
@@ -62,7 +62,6 @@ variable "private_cluster" {
 
 variable "kubernetes_version" {
   type        = string
-  default     = "1.18.17"
   description = "your kubernetes version"
 }
 

--- a/sources/core/modules/harbor/variables.tf
+++ b/sources/core/modules/harbor/variables.tf
@@ -53,5 +53,4 @@ variable "notary_url" {
 
 variable "harbor_version" {
   type    = string
-  default = "1.6.2"
 }


### PR DESCRIPTION
The aim of this PR was to unify the place where the CBS components versioning control will take place. 
Now, the Harbor and kubernetes versions are also controlled in Azure KV.

The code update was  tested on CBS TST environment. 